### PR TITLE
Fix bug with preview mode

### DIFF
--- a/src/Sentry/Initializer.php
+++ b/src/Sentry/Initializer.php
@@ -38,8 +38,12 @@ class Initializer
             $GLOBALS['CONTAO_SENTRY'] = [];
         }
 
-        if (!defined('BE_USER_LOGGED_IN')) {
-            define('BE_USER_LOGGED_IN', false);
+        if (TL_MODE === 'FE') {
+            if (empty(\Input::cookie('BE_USER_AUTH')) || empty(\Input::cookie('FE_PREVIEW'))) {
+                define('BE_USER_LOGGED_IN', false);
+            } else {
+                define('BE_USER_LOGGED_IN', true);
+            }
         }
     }
 


### PR DESCRIPTION
On preview mode hidden elements are not displayed due to BE_USER_LOGGED_IN who is set to false.
This code check if the BE User is authentificated thanks to the auth cookie and set BE_USER_LOGGED_IN to the correct value